### PR TITLE
change http link to https

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 A simple, auto-triggering Oscilloscope that uses the Web Audio API and your Mic input
 
-[Try it now!](http://espruino.github.io/webaudio-oscilloscope/)
+[Try it now!](https://espruino.github.io/webaudio-oscilloscope/)


### PR DESCRIPTION
Security changes, loading the example in Chrome 47 through http yields this error message at the console (osc.js:112):
`getUserMedia() no longer works on insecure origins. To use this feature, you should consider switching your application to a secure origin, such as HTTPS. See https://goo.gl/rStTGz for more details.`
